### PR TITLE
Show OpenCode subscription usage

### DIFF
--- a/CHANGELOG.cn.md
+++ b/CHANGELOG.cn.md
@@ -2,6 +2,12 @@
 
 按版本倒序记录每个版本的变更。当前版本的要点见 [README.cn.md](README.cn.md)。
 
+## 未发布
+
+- OpenCode 终端现在会在供应商余量面板显示通过 OpenCode 连接的 ChatGPT Codex 与 OpenCode Go
+  订阅额度，包括 5 小时、每周和每月窗口及重置时间。默认模型无法确定实际供应商时会同时显示两种
+  已连接订阅；所有数值均直接读取服务自身的内部用量接口，并明确作为非公开接口数据处理。
+
 ## V0.9.0
 
 - 新增第四个 agent：Antigravity，与 Claude Code、Codex CLI、OpenCode 并列。Termexo 会在它的安装器放置

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Release notes for every Termexo version, newest first. The current release is summarised in [README.md](README.md).
 
+## Unreleased
+
+- OpenCode terminals now show the ChatGPT Codex and OpenCode Go subscriptions connected through
+  OpenCode in the provider allowance panel, including their five-hour, weekly and monthly windows
+  and reset times. An unresolved default model shows both connected subscriptions; every figure is
+  read directly from the service's own internal usage endpoint and treated as undocumented data.
+
 ## V0.9.0
 
 - Antigravity is a fourth agent, alongside Claude Code, Codex CLI and OpenCode. Termexo detects

--- a/apps/desktop-ui/src/app/inspector/inspector-panel.spec.ts
+++ b/apps/desktop-ui/src/app/inspector/inspector-panel.spec.ts
@@ -7,7 +7,7 @@ import {
   type ProviderQuota,
 } from '../core/models/agent.models';
 import type { RepositoryOverview } from '../core/models/git.models';
-import { type TerminalSession } from '../core/models/workspace.models';
+import { OPENCODE_DEFAULT_MODEL, type TerminalSession } from '../core/models/workspace.models';
 import { InspectorPanelComponent } from './inspector-panel';
 
 const MINUTE_MS = 60_000;
@@ -95,6 +95,39 @@ const MODEL_PROFILES: ModelProfile[] = [
   },
 ];
 
+const OPENCODE_QUOTAS: ProviderQuota[] = [
+  {
+    profileId: 'agent:opencode:codex',
+    profileName: 'OpenCode · Codex',
+    provider: 'OpenCode',
+    official: false,
+    checkedAt: Date.now(),
+    entries: [
+      {
+        label: '5 小时窗口',
+        unit: 'percent',
+        percent: 25,
+        resetsAt: Date.now() + 60 * MINUTE_MS,
+      },
+    ],
+  },
+  {
+    profileId: 'agent:opencode:go',
+    profileName: 'OpenCode Go',
+    provider: 'OpenCode',
+    official: false,
+    checkedAt: Date.now(),
+    entries: [
+      {
+        label: '每周额度',
+        unit: 'percent',
+        percent: 60,
+        resetsAt: Date.now() + 2 * 24 * 60 * MINUTE_MS,
+      },
+    ],
+  },
+];
+
 /** Opens a collapsible inspector section by its data hook, if it is not already open. */
 function openSection(root: HTMLElement, key: string): void {
   const toggle = root.querySelector<HTMLButtonElement>(`[data-section="${key}"]`);
@@ -164,6 +197,58 @@ describe('InspectorPanelComponent provider allowances', () => {
     fixture.detectChanges();
     expect(root.querySelectorAll('.quota-row')).toHaveLength(1);
     expect(root.textContent).not.toContain('DeepSeek Chat');
+  });
+
+  it('shows only the matching subscription for an explicit OpenCode provider', async () => {
+    fixture.componentRef.setInput('activeTerminal', {
+      ...TERMINAL,
+      agentType: 'opencode',
+      model: 'openai/gpt-5.2-codex',
+      profileId: undefined,
+      accountProfileId: undefined,
+    });
+    fixture.componentRef.setInput('quotas', OPENCODE_QUOTAS);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(root.querySelectorAll('.quota-row')).toHaveLength(1);
+    expect(root.textContent).toContain('OpenCode · Codex');
+    expect(root.textContent).not.toContain('OpenCode Go');
+  });
+
+  it('associates an explicit OpenCode Go model with only the Go subscription', async () => {
+    fixture.componentRef.setInput('activeTerminal', {
+      ...TERMINAL,
+      agentType: 'opencode',
+      model: 'opencode-go/glm-5.2',
+      profileId: undefined,
+      accountProfileId: undefined,
+    });
+    fixture.componentRef.setInput('quotas', OPENCODE_QUOTAS);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(root.querySelectorAll('.quota-row')).toHaveLength(1);
+    expect(root.textContent).toContain('OpenCode Go');
+    expect(root.textContent).not.toContain('OpenCode · Codex');
+  });
+
+  it('shows both OpenCode subscriptions for its default model and headlines the lowest remainder', async () => {
+    fixture.componentRef.setInput('activeTerminal', {
+      ...TERMINAL,
+      agentType: 'opencode',
+      model: OPENCODE_DEFAULT_MODEL,
+      profileId: undefined,
+      accountProfileId: undefined,
+    });
+    fixture.componentRef.setInput('quotas', OPENCODE_QUOTAS);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(root.querySelectorAll('.quota-row')).toHaveLength(2);
+    expect(root.textContent).toContain('OpenCode · Codex');
+    expect(root.textContent).toContain('OpenCode Go');
+    expect(root.querySelector('.overview-stats .stat b')?.textContent?.trim()).toBe('40%');
   });
 
   it('shows live session code changes and opens the full Git view', () => {

--- a/apps/desktop-ui/src/app/inspector/inspector-panel.ts
+++ b/apps/desktop-ui/src/app/inspector/inspector-panel.ts
@@ -39,6 +39,8 @@ const EVENT_LABELS: Readonly<Record<string, string>> = {
 
 /** Matches the backend default for a profile that has never had a threshold set. */
 const DEFAULT_ALERT_THRESHOLD = 80;
+const OPENCODE_CODEX_QUOTA_ID = 'agent:opencode:codex';
+const OPENCODE_GO_QUOTA_ID = 'agent:opencode:go';
 
 /** The collapsible sections below the overview; the overview itself is always open. */
 type SectionKey = 'agents' | 'details' | 'changes' | 'quota' | 'activity';
@@ -138,6 +140,19 @@ export class InspectorPanelComponent {
     const terminal = this.activeTerminal();
     const ids = new Set<string>();
     if (!terminal) {
+      return ids;
+    }
+    if (terminal.agentType === 'opencode') {
+      const model = terminal.model.trim().toLowerCase();
+      if (model.startsWith('openai/')) {
+        ids.add(OPENCODE_CODEX_QUOTA_ID);
+      } else if (model.startsWith('opencode-go/')) {
+        ids.add(OPENCODE_GO_QUOTA_ID);
+      } else {
+        // OpenCode resolves an omitted or unknown provider itself, so either subscription may pay.
+        ids.add(OPENCODE_CODEX_QUOTA_ID);
+        ids.add(OPENCODE_GO_QUOTA_ID);
+      }
       return ids;
     }
     const activeProfile = terminal.profileId

--- a/src-tauri/src/commands/quota.rs
+++ b/src-tauri/src/commands/quota.rs
@@ -27,6 +27,8 @@ const CACHE_TTL: Duration = Duration::from_secs(60);
 /// The agents' usage endpoints are rate limited far more aggressively than the providers' balance
 /// APIs — Anthropic's answers 429 to anything that polls it — so those readings are held longer.
 const AGENT_CACHE_TTL: Duration = Duration::from_secs(300);
+/// OpenCode's plugin refreshes these services once a minute; use the same conservative cadence.
+const OPENCODE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 /// Distinguishes an agent subscription's cache entry from a model profile of the same id.
 const AGENT_CACHE_PREFIX: &str = "agent:";
@@ -57,9 +59,15 @@ struct PendingQuery {
     profile_id: String,
     profile_name: String,
     provider: String,
-    /// Set when this reads an agent's subscription rather than a provider's API key balance.
-    agent_type: Option<String>,
+    parser: QuotaParser,
     request: quota::QuotaRequest,
+}
+
+enum QuotaParser {
+    Provider,
+    Agent(String),
+    OpenCodeCodex,
+    OpenCodeGo,
 }
 
 #[tauri::command]
@@ -105,6 +113,27 @@ pub async fn get_provider_quotas(
             }
         }
         match resolve_agent(&account, &cache_key, now) {
+            Ok(query) => pending.push(query),
+            Err(unavailable) => resolved.push(unavailable),
+        }
+    }
+
+    let opencode_credentials = quota::read_opencode_credentials();
+    for source in [OpenCodeSource::Codex, OpenCodeSource::Go] {
+        if opencode_credentials
+            .as_ref()
+            .is_ok_and(|credentials| !source.is_configured(credentials))
+        {
+            continue;
+        }
+        let id = source.id();
+        if !force {
+            if let Some(cached) = cache.fresh(id, now, OPENCODE_CACHE_TTL) {
+                resolved.push(cached);
+                continue;
+            }
+        }
+        match resolve_opencode(source, opencode_credentials.as_ref(), now) {
             Ok(query) => pending.push(query),
             Err(unavailable) => resolved.push(unavailable),
         }
@@ -188,7 +217,7 @@ fn resolve(
         profile_id: profile.id.clone(),
         profile_name: profile.name.clone(),
         provider: profile.provider.clone(),
-        agent_type: None,
+        parser: QuotaParser::Provider,
         request,
     })
 }
@@ -208,8 +237,83 @@ fn resolve_agent(
         profile_id: cache_key.to_owned(),
         profile_name: account.name.clone(),
         provider: provider.to_owned(),
-        agent_type: Some(account.agent_type.clone()),
+        parser: QuotaParser::Agent(account.agent_type.clone()),
         request: quota::build_agent_request(&account.agent_type, &token),
+    })
+}
+
+#[derive(Clone, Copy)]
+enum OpenCodeSource {
+    Codex,
+    Go,
+}
+
+impl OpenCodeSource {
+    fn id(self) -> &'static str {
+        match self {
+            Self::Codex => quota::OPENCODE_CODEX_QUOTA_ID,
+            Self::Go => quota::OPENCODE_GO_QUOTA_ID,
+        }
+    }
+
+    fn profile_name(self) -> &'static str {
+        match self {
+            Self::Codex => quota::OPENCODE_CODEX_PROFILE_NAME,
+            Self::Go => quota::OPENCODE_GO_PROFILE_NAME,
+        }
+    }
+
+    fn is_configured(self, credentials: &quota::OpenCodeCredentials) -> bool {
+        match self {
+            Self::Codex => credentials.codex.is_some(),
+            Self::Go => credentials.go_api_key.is_some(),
+        }
+    }
+}
+
+fn resolve_opencode(
+    source: OpenCodeSource,
+    credentials: Result<&quota::OpenCodeCredentials, &String>,
+    now: i64,
+) -> Result<PendingQuery, ProviderQuota> {
+    let unavailable = |reason: String| {
+        ProviderQuota::unavailable(
+            source.id(),
+            source.profile_name(),
+            quota::OPENCODE_PROVIDER_LABEL,
+            now,
+            reason,
+        )
+    };
+    let credentials = credentials.map_err(|reason| unavailable(reason.clone()))?;
+    let (parser, request) = match source {
+        OpenCodeSource::Codex => {
+            let credential = credentials
+                .codex
+                .as_ref()
+                .ok_or_else(|| unavailable("OpenCode 尚未连接 ChatGPT Plus/Pro".to_owned()))?;
+            (
+                QuotaParser::OpenCodeCodex,
+                quota::build_opencode_codex_request(credential),
+            )
+        }
+        OpenCodeSource::Go => {
+            let api_key = credentials
+                .go_api_key
+                .as_deref()
+                .ok_or_else(|| unavailable("OpenCode 尚未连接 OpenCode Go".to_owned()))?;
+            (
+                QuotaParser::OpenCodeGo,
+                quota::build_opencode_go_request(api_key),
+            )
+        }
+    };
+    Ok(PendingQuery {
+        profile_id: source.id().to_owned(),
+        profile_name: source.profile_name().to_owned(),
+        provider: quota::OPENCODE_PROVIDER_LABEL.to_owned(),
+        parser,
+        request,
     })
 }
 
@@ -319,9 +423,11 @@ async fn execute(client: reqwest::Client, query: PendingQuery) -> ProviderQuota 
         Err(error) => return unavailable(format!("解析余量响应失败：{error}")),
     };
 
-    let parsed = match query.agent_type.as_deref() {
-        Some(agent_type) => quota::parse_agent_response(agent_type, &body),
-        None => quota::parse_response(&query.provider, &body),
+    let parsed = match &query.parser {
+        QuotaParser::Provider => quota::parse_response(&query.provider, &body),
+        QuotaParser::Agent(agent_type) => quota::parse_agent_response(agent_type, &body),
+        QuotaParser::OpenCodeCodex => quota::parse_opencode_codex_response(&body),
+        QuotaParser::OpenCodeGo => quota::parse_opencode_go_response(&body),
     };
     match parsed {
         Ok(entries) => ProviderQuota {
@@ -415,5 +521,34 @@ mod tests {
         let usage = usage(r#"{"groups":[{"name":"G","buckets":[{"name":"W"}]}]}"#);
 
         assert!(antigravity_entries(&usage).is_empty());
+    }
+
+    #[test]
+    fn opencode_sources_are_offered_only_for_credentials_that_exist() {
+        let credentials = quota::OpenCodeCredentials {
+            codex: Some(quota::OpenCodeCodexCredential {
+                access_token: "token".to_owned(),
+                account_id: None,
+            }),
+            go_api_key: None,
+        };
+
+        assert!(OpenCodeSource::Codex.is_configured(&credentials));
+        assert!(!OpenCodeSource::Go.is_configured(&credentials));
+    }
+
+    #[test]
+    fn an_opencode_source_resolves_to_its_stable_panel_identity() {
+        let credentials = quota::OpenCodeCredentials {
+            codex: None,
+            go_api_key: Some("go-key".to_owned()),
+        };
+
+        let query = resolve_opencode(OpenCodeSource::Go, Ok(&credentials), 42).unwrap();
+
+        assert_eq!(query.profile_id, quota::OPENCODE_GO_QUOTA_ID);
+        assert_eq!(query.profile_name, quota::OPENCODE_GO_PROFILE_NAME);
+        assert_eq!(query.provider, quota::OPENCODE_PROVIDER_LABEL);
+        assert!(matches!(query.parser, QuotaParser::OpenCodeGo));
     }
 }

--- a/src-tauri/src/quota.rs
+++ b/src-tauri/src/quota.rs
@@ -10,8 +10,11 @@
 //! every provider's parsing testable without a network.
 
 use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
+use base64::engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD};
+use base64::Engine;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use url::Url;
@@ -150,6 +153,7 @@ pub fn is_official(provider: &str) -> bool {
         AGENT_CLAUDE_LABEL,
         AGENT_CODEX_LABEL,
         AGENT_ANTIGRAVITY_LABEL,
+        OPENCODE_PROVIDER_LABEL,
     ]
     .iter()
     .any(|known| provider.eq_ignore_ascii_case(known))
@@ -458,11 +462,18 @@ fn minimax_window(
 pub const AGENT_CLAUDE_LABEL: &str = "Claude Code";
 pub const AGENT_CODEX_LABEL: &str = "Codex";
 pub const AGENT_ANTIGRAVITY_LABEL: &str = "Antigravity";
+pub const OPENCODE_PROVIDER_LABEL: &str = "OpenCode";
+pub const OPENCODE_CODEX_QUOTA_ID: &str = "agent:opencode:codex";
+pub const OPENCODE_GO_QUOTA_ID: &str = "agent:opencode:go";
+pub const OPENCODE_CODEX_PROFILE_NAME: &str = "OpenCode · Codex";
+pub const OPENCODE_GO_PROFILE_NAME: &str = "OpenCode Go";
 
 /// The endpoint behind Claude Code's `/usage`.
 const CLAUDE_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
 /// The endpoint Codex CLI polls for its `/status` figures.
 const CODEX_USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
+/// The endpoint OpenCode Go uses for its rolling, weekly and monthly subscription windows.
+const OPENCODE_GO_USAGE_URL: &str = "https://opencode.ai/zen/go/v1/usage";
 /// The beta gate on the usage endpoint; without it the request is rejected outright.
 const CLAUDE_OAUTH_BETA: &str = "oauth-2025-04-20";
 /// Anthropic buckets this endpoint by User-Agent. A client that does not look like Claude Code
@@ -475,6 +486,123 @@ pub fn agent_display_name(agent_type: &str) -> &'static str {
         "antigravity" => AGENT_ANTIGRAVITY_LABEL,
         _ => AGENT_CODEX_LABEL,
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenCodeCodexCredential {
+    pub access_token: String,
+    pub account_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OpenCodeCredentials {
+    pub codex: Option<OpenCodeCodexCredential>,
+    pub go_api_key: Option<String>,
+}
+
+/// Reads only the two credentials needed for allowance requests from OpenCode's own auth store.
+pub fn read_opencode_credentials() -> Result<OpenCodeCredentials, String> {
+    let fallback_go_api_key = std::env::var("OPENCODE_API_KEY").ok();
+    let injected = std::env::var("OPENCODE_AUTH_CONTENT")
+        .ok()
+        .and_then(|content| serde_json::from_str::<Value>(&content).ok())
+        .filter(Value::is_object);
+    let auth = match injected {
+        Some(auth) => auth,
+        None => {
+            let path = opencode_auth_path();
+            match fs::read_to_string(&path) {
+                Ok(content) => serde_json::from_str::<Value>(&content)
+                    .map_err(|error| format!("OpenCode 登录凭据解析失败：{error}"))?,
+                Err(error) if error.kind() == ErrorKind::NotFound => Value::Object(Map::new()),
+                Err(error) => return Err(format!("无法读取 OpenCode 登录凭据：{error}")),
+            }
+        }
+    };
+    parse_opencode_credentials(&auth, fallback_go_api_key.as_deref())
+}
+
+fn opencode_auth_path() -> PathBuf {
+    let data_home = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("USERPROFILE")
+                .or_else(|| std::env::var_os("HOME"))
+                .map(PathBuf::from)
+                .map(|home| home.join(".local").join("share"))
+        });
+    data_home
+        .unwrap_or_default()
+        .join("opencode")
+        .join("auth.json")
+}
+
+fn parse_opencode_credentials(
+    auth: &Value,
+    fallback_go_api_key: Option<&str>,
+) -> Result<OpenCodeCredentials, String> {
+    let auth = auth
+        .as_object()
+        .ok_or_else(|| "OpenCode 登录凭据必须是 JSON 对象".to_owned())?;
+    let codex = auth
+        .get("openai")
+        .and_then(Value::as_object)
+        .filter(|credential| credential.get("type").and_then(Value::as_str) == Some("oauth"))
+        .and_then(|credential| {
+            let access_token = credential
+                .get("access")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|token| !token.is_empty())?;
+            let account_id = credential
+                .get("accountId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(str::to_owned)
+                .or_else(|| chatgpt_account_id(access_token));
+            Some(OpenCodeCodexCredential {
+                access_token: access_token.to_owned(),
+                account_id,
+            })
+        });
+    let stored_go_api_key = auth
+        .get("opencode-go")
+        .and_then(Value::as_object)
+        .filter(|credential| credential.get("type").and_then(Value::as_str) == Some("api"))
+        .and_then(|credential| credential.get("key"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|key| !key.is_empty());
+    let go_api_key = stored_go_api_key
+        .or_else(|| {
+            fallback_go_api_key
+                .map(str::trim)
+                .filter(|key| !key.is_empty())
+        })
+        .map(str::to_owned);
+    Ok(OpenCodeCredentials { codex, go_api_key })
+}
+
+/// Reads the account claim OpenAI places in its OAuth JWT without validating or logging the token.
+fn chatgpt_account_id(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| URL_SAFE.decode(payload))
+        .ok()?;
+    let claims = serde_json::from_slice::<Value>(&decoded).ok()?;
+    claims
+        .get("chatgpt_account_id")
+        .or_else(|| {
+            claims
+                .get("https://api.openai.com/auth")
+                .and_then(|auth| auth.get("chatgpt_account_id"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
 }
 
 /// Locates an agent's configuration home, honouring the per-account isolation.
@@ -546,6 +674,78 @@ pub fn build_agent_request(agent_type: &str, token: &str) -> QuotaRequest {
     } else {
         QuotaRequest::bearer(CODEX_USAGE_URL.to_owned(), token)
     }
+}
+
+pub fn build_opencode_codex_request(credential: &OpenCodeCodexCredential) -> QuotaRequest {
+    let mut request = QuotaRequest::bearer(CODEX_USAGE_URL.to_owned(), &credential.access_token);
+    request
+        .headers
+        .push(("Accept", "application/json".to_owned()));
+    if let Some(account_id) = credential.account_id.as_deref() {
+        request
+            .headers
+            .push(("ChatGPT-Account-Id", account_id.to_owned()));
+    }
+    request
+}
+
+pub fn build_opencode_go_request(api_key: &str) -> QuotaRequest {
+    let mut request = QuotaRequest::bearer(OPENCODE_GO_USAGE_URL.to_owned(), api_key);
+    request
+        .headers
+        .push(("Accept", "application/json".to_owned()));
+    request
+}
+
+pub fn parse_opencode_codex_response(body: &Value) -> Result<Vec<QuotaEntry>, String> {
+    let rate_limit = body
+        .get("rate_limit")
+        .ok_or_else(|| "OpenCode Codex 未返回订阅额度".to_owned())?;
+    Ok(vec![
+        parse_used_window(
+            rate_limit.get("primary_window"),
+            "5 小时窗口",
+            "used_percent",
+            "reset_at",
+        )?,
+        parse_used_window(
+            rate_limit.get("secondary_window"),
+            "每周额度",
+            "used_percent",
+            "reset_at",
+        )?,
+    ])
+}
+
+pub fn parse_opencode_go_response(body: &Value) -> Result<Vec<QuotaEntry>, String> {
+    let usage = body
+        .get("usage")
+        .ok_or_else(|| "OpenCode Go 未返回订阅额度".to_owned())?;
+    Ok(vec![
+        parse_used_window(usage.get("rolling"), "5 小时窗口", "percent", "resetsAt")?,
+        parse_used_window(usage.get("weekly"), "每周额度", "percent", "resetsAt")?,
+        parse_used_window(usage.get("monthly"), "每月额度", "percent", "resetsAt")?,
+    ])
+}
+
+fn parse_used_window(
+    value: Option<&Value>,
+    label: &str,
+    percent_key: &str,
+    reset_key: &str,
+) -> Result<QuotaEntry, String> {
+    let value = value.ok_or_else(|| format!("{label}不可用"))?;
+    let percent = loose_number(value, percent_key)
+        .filter(|percent| percent.is_finite())
+        .ok_or_else(|| format!("{label}的已用比例无效"))?;
+    let resets_at = value
+        .get(reset_key)
+        .and_then(parse_timestamp)
+        .ok_or_else(|| format!("{label}的重置时间无效"))?;
+    let mut entry = QuotaEntry::new(label, QuotaUnit::Percent);
+    entry.percent = Some(percent.clamp(0.0, 100.0));
+    entry.resets_at = Some(resets_at);
+    Ok(entry)
 }
 
 /// Turns an agent's usage response into allowance lines.
@@ -1019,6 +1219,7 @@ mod tests {
         assert!(!is_official(AGENT_CLAUDE_LABEL));
         assert!(!is_official(AGENT_CODEX_LABEL));
         assert!(!is_official(AGENT_ANTIGRAVITY_LABEL));
+        assert!(!is_official(OPENCODE_PROVIDER_LABEL));
     }
 
     #[test]
@@ -1102,5 +1303,119 @@ mod tests {
         assert!(error.contains("未识别"));
         assert!(error.contains("plan"));
         assert!(!error.contains("pro"));
+    }
+
+    #[test]
+    fn reads_opencode_codex_and_go_credentials_without_exposing_other_auth_entries() {
+        let payload = URL_SAFE_NO_PAD.encode(
+            br#"{"https://api.openai.com/auth":{"chatgpt_account_id":"account-from-jwt"}}"#,
+        );
+        let auth = json!({
+            "openai": { "type": "oauth", "access": format!("header.{payload}.signature") },
+            "opencode-go": { "type": "api", "key": "stored-go-key" },
+            "another-provider": { "type": "api", "key": "must-not-be-read" }
+        });
+
+        let credentials = parse_opencode_credentials(&auth, Some("fallback-go-key")).unwrap();
+
+        assert_eq!(
+            credentials.codex,
+            Some(OpenCodeCodexCredential {
+                access_token: format!("header.{payload}.signature"),
+                account_id: Some("account-from-jwt".to_owned()),
+            })
+        );
+        assert_eq!(credentials.go_api_key.as_deref(), Some("stored-go-key"));
+    }
+
+    #[test]
+    fn opencode_go_uses_the_environment_fallback_only_without_a_stored_key() {
+        let credentials =
+            parse_opencode_credentials(&json!({}), Some("environment-go-key")).unwrap();
+
+        assert_eq!(
+            credentials.go_api_key.as_deref(),
+            Some("environment-go-key")
+        );
+        assert!(credentials.codex.is_none());
+    }
+
+    #[test]
+    fn builds_opencode_usage_requests_with_the_required_identity_headers() {
+        let codex = build_opencode_codex_request(&OpenCodeCodexCredential {
+            access_token: "codex-token".to_owned(),
+            account_id: Some("account-2".to_owned()),
+        });
+        assert_eq!(codex.url, CODEX_USAGE_URL);
+        assert_eq!(
+            codex.headers,
+            vec![
+                (AUTHORIZATION, "Bearer codex-token".to_owned()),
+                ("Accept", "application/json".to_owned()),
+                ("ChatGPT-Account-Id", "account-2".to_owned()),
+            ]
+        );
+
+        let go = build_opencode_go_request("go-key");
+        assert_eq!(go.url, OPENCODE_GO_USAGE_URL);
+        assert_eq!(
+            go.headers,
+            vec![
+                (AUTHORIZATION, "Bearer go-key".to_owned()),
+                ("Accept", "application/json".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_opencode_codex_primary_and_secondary_windows() {
+        let entries = parse_opencode_codex_response(&json!({
+            "rate_limit": {
+                "primary_window": { "used_percent": 25, "reset_at": 1_800_000_000u64 },
+                "secondary_window": { "used_percent": 50, "reset_at": 1_800_100_000u64 }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].label, "5 小时窗口");
+        assert_eq!(entries[0].percent, Some(25.0));
+        assert_eq!(entries[0].resets_at, Some(1_800_000_000_000));
+        assert_eq!(entries[1].label, "每周额度");
+        assert_eq!(entries[1].percent, Some(50.0));
+    }
+
+    #[test]
+    fn parses_all_opencode_go_windows() {
+        let entries = parse_opencode_go_response(&json!({
+            "usage": {
+                "rolling": { "percent": 20, "resetsAt": "2027-01-15T10:00:00.000Z" },
+                "weekly": { "percent": 40, "resetsAt": "2027-01-18T00:00:00.000Z" },
+                "monthly": { "percent": 60, "resetsAt": "2027-02-01T00:00:00.000Z" }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].label, "5 小时窗口");
+        assert_eq!(entries[0].percent, Some(20.0));
+        assert_eq!(entries[1].label, "每周额度");
+        assert_eq!(entries[2].label, "每月额度");
+        assert_eq!(entries[2].percent, Some(60.0));
+    }
+
+    #[test]
+    fn rejects_an_incomplete_opencode_usage_window() {
+        let error = parse_opencode_go_response(&json!({
+            "usage": {
+                "rolling": { "percent": null, "resetsAt": "2027-01-15T10:00:00.000Z" },
+                "weekly": { "percent": 40, "resetsAt": "2027-01-18T00:00:00.000Z" },
+                "monthly": { "percent": 60, "resetsAt": "2027-02-01T00:00:00.000Z" }
+            }
+        }))
+        .unwrap_err();
+
+        assert!(error.contains("5 小时窗口"));
+        assert!(error.contains("已用比例无效"));
     }
 }


### PR DESCRIPTION
## 变更说明
- 安全读取 OpenCode 已连接的 ChatGPT Codex 与 OpenCode Go 凭据，不记录或持久化密钥
- 复用现有供应商余量链路，查询并解析 5 小时、每周和每月订阅额度窗口
- OpenCode 显式选择供应商时仅显示对应额度；使用默认或未知模型时显示两种已连接订阅
- 明确将两个用量接口标记为非公开接口，并补充前后端测试与更新记录

## 验证结果
- cargo test --manifest-path src-tauri/Cargo.toml：281 项通过，2 项按设计忽略
- npm test：390 项通过
- npm run build：构建通过，仅有现存的 bundle 与样式预算警告
- 变更文件通过 Prettier 与 rustfmt 检查